### PR TITLE
fix: convert pressure to native integration unit while restoring

### DIFF
--- a/custom_components/yandex_weather/sensor.py
+++ b/custom_components/yandex_weather/sensor.py
@@ -175,7 +175,10 @@ class YandexWeatherSensor(SensorEntity, CoordinatorEntity, RestoreEntity):
         if self.entity_description.key == ATTR_API_WEATHER_TIME:
             self._attr_native_value = datetime.fromisoformat(state.state)
         else:
-            self._attr_native_value = state.state
+            if self.entity_description.key == ATTR_API_PRESSURE:
+                self._attr_native_value = int(state.state) / 100
+            else:
+                self._attr_native_value = state.state
         # ToDo: restore icon for ATTR_API_YA_CONDITION
         self.async_write_ha_state()
 

--- a/custom_components/yandex_weather/weather.py
+++ b/custom_components/yandex_weather/weather.py
@@ -79,7 +79,7 @@ class YandexWeather(WeatherEntity, CoordinatorEntity, RestoreEntity):
         _LOGGER.debug(f"state for restore: {state}")
         self._attr_temperature = state.attributes.get("temperature")
         self._attr_condition = state.state
-        self._attr_pressure = state.attributes.get("pressure")
+        self._attr_pressure = state.attributes.get("pressure") / 100
         self._attr_humidity = state.attributes.get("humidity")
         self._attr_wind_speed = state.attributes.get("wind_speed")
         self._attr_wind_bearing = state.attributes.get("wind_bearing")


### PR DESCRIPTION
We assume that pressure in hPa, but while restoring data it restores in Pa, so we should convert it to hPa.