### PR TITLE
chore: add __pycache__ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /venv/
+__pycache__


### PR DESCRIPTION
This will clean up the `git status` output.