### PR TITLE
fix(weather::forecasts): add additional forecast data for clock-weather-card

### DIFF
--- a/custom_components/yandex_weather/updater.py
+++ b/custom_components/yandex_weather/updater.py
@@ -113,7 +113,9 @@ FORECAST_ATTRIBUTE_TRANSLATION: list[AttributeMapper] = [
         "wind_dir", ATTR_FORECAST_WIND_BEARING, mapping=WIND_DIRECTION_MAPPING
     ),
     AttributeMapper("temp_avg", ATTR_FORECAST_NATIVE_TEMP),
+    AttributeMapper("temp_avg", "temperature"),
     AttributeMapper("temp_min", ATTR_FORECAST_NATIVE_TEMP_LOW),
+    AttributeMapper("temp_min", "templow"),
     AttributeMapper("pressure_pa", ATTR_FORECAST_NATIVE_PRESSURE),
     AttributeMapper("wind_speed", ATTR_FORECAST_NATIVE_WIND_SPEED, default=0),
     AttributeMapper("prec_mm", ATTR_FORECAST_NATIVE_PRECIPITATION, default=0),

--- a/custom_components/yandex_weather/weather.py
+++ b/custom_components/yandex_weather/weather.py
@@ -6,7 +6,6 @@ from datetime import datetime, timezone
 import logging
 
 from homeassistant.components.weather import (
-    ATTR_FORECAST_IS_DAYTIME,
     ATTR_WEATHER_PRECIPITATION_UNIT,
     ATTR_WEATHER_PRESSURE_UNIT,
     ATTR_WEATHER_TEMPERATURE_UNIT,


### PR DESCRIPTION
https://github.com/pkissling/clock-weather-card with
```yaml
type: custom:clock-weather-card
entity: weather.yandex_weather
hourly_forecast: true
```
now will show pretty forecast from the integration.

Fix #112