### PR TITLE
fix(weather): Use Ynadex image URL for `entity_picture`

### DIFF
--- a/custom_components/yandex_weather/const.py
+++ b/custom_components/yandex_weather/const.py
@@ -156,7 +156,7 @@ class ConditionImage:
 CONDITION_IMAGE: dict[str, ConditionImage] = {
     "HomeAssistant": None,
     "Yandex": ConditionImage(
-        link="https://yastatic.net/weather/i/icons/funky/dark/{}.svg",
+        link="{}",  # Now Yandex send full image URL
         mapping=None,
     ),
     "Custom weather card animated": ConditionImage(

--- a/custom_components/yandex_weather/updater.py
+++ b/custom_components/yandex_weather/updater.py
@@ -278,9 +278,9 @@ class WeatherUpdater(DataUpdateCoordinator):
 
             await self.fill_forecast(now, result, weather["forecast"]["days"])
 
-            result[ATTR_MIN_FORECAST_TEMPERATURE] = await self.get_min_forecast_temperature(
-                result[ATTR_FORECAST_DATA]
-            )
+            result[
+                ATTR_MIN_FORECAST_TEMPERATURE
+            ] = await self.get_min_forecast_temperature(result[ATTR_FORECAST_DATA])
 
             return result
 


### PR DESCRIPTION
Now API returns full URL, not just image file name.

Fixes #133