### PR TITLE
Fix import error

### DIFF
--- a/custom_components/yandex_weather/sensor.py
+++ b/custom_components/yandex_weather/sensor.py
@@ -72,7 +72,7 @@ WEATHER_SENSORS: tuple[SensorEntityDescription, ...] = (
         entity_registry_enabled_default=False,
         icon="mdi:compass-rose",
         translation_key=ATTR_API_WIND_BEARING,
-        state_class=SensorStateClass.WIND_DIRECTION,
+        state_class=SensorStateClass.MEASUREMENT,
         device_class=SensorDeviceClass.WIND_DIRECTION,
         native_unit_of_measurement=DEGREE,
     ),


### PR DESCRIPTION
```
Unexpected exception importing platform custom_components.yandex_weather.sensor

Traceback (most recent call last):
  File "/srv/homeassistant/lib64/python3.13/site-packages/homeassistant/loader.py", line 1260, in _load_platform
    cache[full_name] = self._import_platform(platform_name)
                       ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^
  File "/srv/homeassistant/lib64/python3.13/site-packages/homeassistant/loader.py", line 1292, in _import_platform
    return importlib.import_module(f"{self.pkg_path}.{platform_name}")
           ~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/srv/homeassistant/lib64/python3.13/site-packages/homeassistant/util/loop.py", line 201, in protected_loop_func
    return func(*args, **kwargs)
  File "/usr/lib64/python3.13/importlib/__init__.py", line 88, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1387, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 935, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 1026, in exec_module
  File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
  File "/raid/homeassistant/custom_components/yandex_weather/sensor.py", line 75, in <module>
    state_class=SensorStateClass.WIND_DIRECTION,
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: type object 'SensorStateClass' has no attribute 'WIND_DIRECTION'
```